### PR TITLE
✨ Implement CareSubject CRUD functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // Hibernate Types for JSON support
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.7.3'
+
     // Development Tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/carehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/carehub/common/exception/GlobalExceptionHandler.java
@@ -1,53 +1,156 @@
 package carehub.common.exception;
 
 import carehub.common.dto.response.ApiResponse;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // 유효성 검증 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        log.error("=== 유효성 검증 실패 ===");
+
         BindingResult result = ex.getBindingResult();
         StringBuilder errorMessage = new StringBuilder();
 
         for (FieldError error : result.getFieldErrors()) {
+            log.error("필드 오류 - 필드: {}, 입력값: {}, 메시지: {}",
+                    error.getField(), error.getRejectedValue(), error.getDefaultMessage());
+
             errorMessage.append(error.getField())
                     .append(": ")
                     .append(error.getDefaultMessage())
                     .append(", ");
         }
 
-        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, errorMessage.toString()
-        );
+        String finalErrorMessage = errorMessage.toString();
+        if (finalErrorMessage.endsWith(", ")) {
+            finalErrorMessage = finalErrorMessage.substring(0, finalErrorMessage.length() - 2);
+        }
 
+        log.error("최종 오류 메시지: {}", finalErrorMessage);
+
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, finalErrorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // JSON 파싱 오류 처리 (Gender enum 변환 오류 등)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.error("=== JSON 파싱 오류 발생 ===");
+        log.error("원본 오류: {}", ex.getMessage());
+
+        String errorMessage = "잘못된 요청 데이터입니다.";
+
+        // 구체적인 오류 원인 파악
+        Throwable cause = ex.getCause();
+        if (cause instanceof InvalidFormatException) {
+            InvalidFormatException ife = (InvalidFormatException) cause;
+            String fieldName = getFieldName(ife);
+            Object invalidValue = ife.getValue();
+            Class<?> targetType = ife.getTargetType();
+
+            log.error("잘못된 형식 오류 - 필드: {}, 입력값: {}, 대상 타입: {}",
+                    fieldName, invalidValue, targetType.getSimpleName());
+
+            // Gender enum 관련 오류인 경우
+            if (targetType.isEnum() && fieldName.contains("gender")) {
+                errorMessage = String.format("성별 값이 올바르지 않습니다. '%s'는 유효하지 않은 값입니다. (유효한 값: M, F, O)", invalidValue);
+            } else if (targetType.isEnum()) {
+                errorMessage = String.format("'%s' 필드의 값 '%s'가 올바르지 않습니다.", fieldName, invalidValue);
+            } else {
+                errorMessage = String.format("'%s' 필드의 형식이 올바르지 않습니다. 입력값: '%s'", fieldName, invalidValue);
+            }
+        } else if (cause instanceof JsonMappingException) {
+            JsonMappingException jme = (JsonMappingException) cause;
+            String fieldName = getFieldName(jme);
+            log.error("JSON 매핑 오류 - 필드: {}", fieldName);
+            errorMessage = String.format("'%s' 필드를 처리하는 중 오류가 발생했습니다.", fieldName);
+        }
+
+        // Gender 관련 오류 메시지가 포함된 경우 특별 처리
+        if (ex.getMessage().contains("Gender") || ex.getMessage().contains("gender")) {
+            errorMessage = "성별 정보가 올바르지 않습니다. 성별을 선택해주세요. (남성, 여성, 기타 중 선택)";
+        }
+
+        log.error("최종 오류 메시지: {}", errorMessage);
+
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, errorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // IllegalArgumentException 처리 (Gender.fromCode에서 발생하는 오류 등)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("=== 잘못된 인수 오류 발생 ===");
+        log.error("오류 메시지: {}", ex.getMessage());
+
+        String errorMessage = ex.getMessage();
+
+        // Gender 관련 오류인 경우 사용자 친화적 메시지로 변경
+        if (errorMessage.contains("Unknown gender code")) {
+            errorMessage = "성별 정보가 올바르지 않습니다. 성별을 다시 선택해주세요.";
+        }
+
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, errorMessage);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     // 비즈니스 예외 처리
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {
-        ApiResponse<Void> response = ApiResponse.error(ex.getErrorCode(), ex.getMessage()
-        );
+        log.error("=== 비즈니스 예외 발생 ===");
+        log.error("오류 코드: {}, 오류 메시지: {}", ex.getErrorCode().getCode(), ex.getMessage());
 
+        ApiResponse<Void> response = ApiResponse.error(ex.getErrorCode(), ex.getMessage());
         return ResponseEntity.status(ex.getErrorCode().getStatus()).body(response);
     }
 
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleAllExceptions(Exception ex) {
+        log.error("=== 예상치 못한 예외 발생 ===");
+        log.error("예외 타입: {}", ex.getClass().getSimpleName());
+        log.error("예외 메시지: {}", ex.getMessage());
+        log.error("상세 스택 트레이스:", ex);
+
         ApiResponse<Void> response = ApiResponse.error(
                 ErrorCode.INTERNAL_SERVER_ERROR,
                 "서버 내부 오류가 발생했습니다."
         );
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    /**
+     * JsonMappingException에서 필드명 추출
+     */
+    private String getFieldName(JsonMappingException ex) {
+        if (ex.getPath() != null && !ex.getPath().isEmpty()) {
+            return ex.getPath().get(ex.getPath().size() - 1).getFieldName();
+        }
+        return "unknown";
+    }
+
+    /**
+     * InvalidFormatException에서 필드명 추출
+     */
+    private String getFieldName(InvalidFormatException ex) {
+        if (ex.getPath() != null && !ex.getPath().isEmpty()) {
+            return ex.getPath().get(ex.getPath().size() - 1).getFieldName();
+        }
+        return "unknown";
     }
 }

--- a/src/main/java/carehub/config/JacksonConfig.java
+++ b/src/main/java/carehub/config/JacksonConfig.java
@@ -1,0 +1,35 @@
+package carehub.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Slf4j
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        log.info("커스텀 ObjectMapper 설정 시작");
+        ObjectMapper mapper = Jackson2ObjectMapperBuilder
+                .json()
+                .modules(new JavaTimeModule(), new ParameterNamesModule())
+                .build();
+
+        mapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        log.info("커스텀 ObjectMapper 설정 완료");
+        return mapper;
+    }
+}

--- a/src/main/java/carehub/domain/caresubject/CareSubject.java
+++ b/src/main/java/carehub/domain/caresubject/CareSubject.java
@@ -24,7 +24,8 @@ import java.util.Map;
 @Entity
 @Table(name = "care_subjects", indexes = {
         @Index(name = "idx_care_subject_created_by", columnList = "created_by"),
-        @Index(name = "idx_care_subject_active", columnList = "is_active")
+        @Index(name = "idx_care_subject_active", columnList = "is_active"),
+        @Index(name = "idx_care_subject_type", columnList = "subject_type")
 })
 @Data
 @Builder
@@ -43,7 +44,7 @@ public class CareSubject {
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = true, length = 10)
     private Gender gender;
 
     @Column(name = "blood_type", length = 5)
@@ -54,6 +55,12 @@ public class CareSubject {
 
     @Column(name = "birth_height", precision = 5, scale = 2)
     private BigDecimal birthHeight;
+
+    // 케어 대상 유형 추가 (필수)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "subject_type", nullable = false, length = 20)
+    @Builder.Default
+    private CareSubjectType subjectType = CareSubjectType.INFANT;
 
     @Type(JsonType.class)
     @Column(name = "additional_info", columnDefinition = "jsonb")
@@ -71,6 +78,11 @@ public class CareSubject {
     @JoinColumn(name = "created_by", nullable = false)
     private User createdBy;
 
+    // 임시: main_caregiver_id 컬럼 대응 (항상 createdBy와 동일하게 설정)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_caregiver_id", nullable = false)
+    private User mainCaregiver;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -83,6 +95,31 @@ public class CareSubject {
     @JsonManagedReference
     @Builder.Default
     private List<Guardian> guardians = new ArrayList<>();
+
+    // 신생아 전용 필드들
+    @Column(name = "birth_weight_grams")
+    private Integer birthWeightGrams;
+
+    @Column(name = "birth_height_cm")
+    private Integer birthHeightCm;
+
+    @Column(name = "head_circumference_cm")
+    private Integer headCircumferenceCm;
+
+    @Column(name = "gestational_age_weeks")
+    private Integer gestationalAgeWeeks;
+
+    @Column(name = "delivery_type", length = 20)
+    private String deliveryType;
+
+    @Column(name = "allergies", length = 500)
+    private String allergies;
+
+    @Column(name = "special_care_needs", length = 1000)
+    private String specialCareNeeds;
+
+    @Column(name = "last_checkup_date")
+    private LocalDate lastCheckupDate;
 
     public void addGuardian(Guardian guardian) {
         guardians.add(guardian);
@@ -102,5 +139,58 @@ public class CareSubject {
     public long getAgeInDays() {
         LocalDate now = LocalDate.now();
         return java.time.temporal.ChronoUnit.DAYS.between(birthDate, now);
+    }
+
+    /**
+     * 케어 대상 유형 결정 로직
+     * 신생아 전용 필드가 하나라도 있으면 INFANT, 없으면 DEFAULT
+     */
+    public void determineSubjectType() {
+        if (hasInfantSpecificData()) {
+            this.subjectType = CareSubjectType.INFANT;
+        } else {
+            this.subjectType = CareSubjectType.DEFAULT;
+        }
+    }
+
+    /**
+     * 신생아 전용 데이터 존재 여부 확인
+     */
+    private boolean hasInfantSpecificData() {
+        return birthWeightGrams != null
+                || birthHeightCm != null
+                || headCircumferenceCm != null
+                || gestationalAgeWeeks != null
+                || deliveryType != null
+                || allergies != null
+                || specialCareNeeds != null
+                || lastCheckupDate != null;
+    }
+
+    /**
+     * 신생아 전용 필드 설정
+     */
+    public void setInfantData(Integer birthWeightGrams, Integer birthHeightCm,
+                              Integer headCircumferenceCm, Integer gestationalAgeWeeks,
+                              String deliveryType, String allergies,
+                              String specialCareNeeds, LocalDate lastCheckupDate) {
+        this.birthWeightGrams = birthWeightGrams;
+        this.birthHeightCm = birthHeightCm;
+        this.headCircumferenceCm = headCircumferenceCm;
+        this.gestationalAgeWeeks = gestationalAgeWeeks;
+        this.deliveryType = deliveryType;
+        this.allergies = allergies;
+        this.specialCareNeeds = specialCareNeeds;
+        this.lastCheckupDate = lastCheckupDate;
+
+        // 자동으로 타입 결정
+        determineSubjectType();
+    }
+
+    /**
+     * 임시: mainCaregiver를 createdBy와 동일하게 설정하는 헬퍼 메서드
+     */
+    public void syncMainCaregiverWithCreatedBy() {
+        this.mainCaregiver = this.createdBy;
     }
 }

--- a/src/main/java/carehub/domain/caresubject/CareSubject.java
+++ b/src/main/java/carehub/domain/caresubject/CareSubject.java
@@ -1,0 +1,106 @@
+package carehub.domain.caresubject;
+
+import carehub.domain.guardian.Guardian;
+import carehub.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "care_subjects", indexes = {
+        @Index(name = "idx_care_subject_created_by", columnList = "created_by"),
+        @Index(name = "idx_care_subject_active", columnList = "is_active")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareSubject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Gender gender;
+
+    @Column(name = "blood_type", length = 5)
+    private String bloodType;
+
+    @Column(name = "birth_weight", precision = 5, scale = 2)
+    private BigDecimal birthWeight;
+
+    @Column(name = "birth_height", precision = 5, scale = 2)
+    private BigDecimal birthHeight;
+
+    @Type(JsonType.class)
+    @Column(name = "additional_info", columnDefinition = "jsonb")
+    @Builder.Default
+    private Map<String, Object> additionalInfo = new HashMap<>();
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "careSubject", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    @Builder.Default
+    private List<Guardian> guardians = new ArrayList<>();
+
+    public void addGuardian(Guardian guardian) {
+        guardians.add(guardian);
+        guardian.setCareSubject(this);
+    }
+
+    public void removeGuardian(Guardian guardian) {
+        guardians.remove(guardian);
+        guardian.setCareSubject(null);
+    }
+
+    public int getAgeInMonths() {
+        LocalDate now = LocalDate.now();
+        return (int) java.time.Period.between(birthDate, now).toTotalMonths();
+    }
+
+    public long getAgeInDays() {
+        LocalDate now = LocalDate.now();
+        return java.time.temporal.ChronoUnit.DAYS.between(birthDate, now);
+    }
+}

--- a/src/main/java/carehub/domain/caresubject/CareSubjectRepository.java
+++ b/src/main/java/carehub/domain/caresubject/CareSubjectRepository.java
@@ -1,0 +1,59 @@
+package carehub.domain.caresubject;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CareSubjectRepository extends JpaRepository<CareSubject, Long> {
+
+    /**
+     * 특정 사용자가 생성한 케어 대상 목록 조회
+     */
+    List<CareSubject> findByCreatedByIdAndIsActiveTrue(Long createdById);
+
+    /**
+     * 특정 사용자가 보호자로 등록된 케어 대상 목록 조회 (승인된 것만)
+     */
+    @Query("SELECT DISTINCT cs FROM CareSubject cs " +
+            "JOIN FETCH cs.guardians g " +
+            "JOIN FETCH g.user " +
+            "WHERE g.user.id = :userId AND g.status = 'ACCEPTED' AND cs.isActive = true")
+    List<CareSubject> findByGuardianUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자가 접근 가능한 모든 케어 대상 조회 (생성자 + 보호자)
+     * N+1 문제 방지를 위해 필요한 연관 엔티티들을 함께 로드
+     */
+    @Query("SELECT DISTINCT cs FROM CareSubject cs " +
+            "LEFT JOIN FETCH cs.guardians g " +
+            "LEFT JOIN FETCH g.user " +
+            "LEFT JOIN FETCH cs.createdBy " +
+            "WHERE (cs.createdBy.id = :userId OR (g.user.id = :userId AND g.status = 'ACCEPTED')) " +
+            "AND cs.isActive = true")
+    List<CareSubject> findAccessibleByUserId(@Param("userId") Long userId);
+
+    /**
+     * ID와 사용자 ID로 접근 가능한 케어 대상 조회
+     * 상세 조회용으로 모든 필요한 연관 엔티티를 함께 로드
+     */
+    @Query("SELECT cs FROM CareSubject cs " +
+            "LEFT JOIN FETCH cs.guardians g " +
+            "LEFT JOIN FETCH g.user " +
+            "LEFT JOIN FETCH cs.createdBy " +
+            "WHERE cs.id = :careSubjectId " +
+            "AND (cs.createdBy.id = :userId OR (g.user.id = :userId AND g.status = 'ACCEPTED')) " +
+            "AND cs.isActive = true")
+    Optional<CareSubject> findByIdAndAccessibleByUserId(@Param("careSubjectId") Long careSubjectId,
+                                                        @Param("userId") Long userId);
+
+    /**
+     * 특정 사용자가 PRIMARY 보호자인 케어 대상 조회
+     */
+    @Query("SELECT DISTINCT cs FROM CareSubject cs " +
+            "JOIN cs.guardians g " +
+            "WHERE g.user.id = :userId AND g.role = 'PRIMARY' AND g.status = 'ACCEPTED' AND cs.isActive = true")
+    List<CareSubject> findByPrimaryGuardianUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/carehub/domain/caresubject/CareSubjectService.java
+++ b/src/main/java/carehub/domain/caresubject/CareSubjectService.java
@@ -1,0 +1,177 @@
+package carehub.domain.caresubject;
+
+import carehub.common.exception.BusinessException;
+import carehub.common.exception.ErrorCode;
+import carehub.domain.guardian.Guardian;
+import carehub.domain.guardian.GuardianRepository;
+import carehub.domain.guardian.GuardianRole;
+import carehub.domain.guardian.GuardianStatus;
+import carehub.domain.guardian.Permission;
+import carehub.domain.user.User;
+import carehub.domain.user.UserRepository;
+import carehub.web.dto.caresubject.CareSubjectCreateRequest;
+import carehub.web.dto.caresubject.CareSubjectUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CareSubjectService {
+
+    private final CareSubjectRepository careSubjectRepository;
+    private final GuardianRepository guardianRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 케어 대상 생성
+     */
+    @Transactional
+    public CareSubject createCareSubject(CareSubjectCreateRequest request, Long createdById) {
+        User creator = userRepository.findById(createdById)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        CareSubject careSubject = CareSubject.builder()
+                .name(request.getName())
+                .birthDate(request.getBirthDate())
+                .gender(request.getGender())
+                .bloodType(request.getBloodType())
+                .birthWeight(request.getBirthWeight())
+                .birthHeight(request.getBirthHeight())
+                .profileImageUrl(request.getProfileImageUrl())
+                .additionalInfo(request.getAdditionalInfo())
+                .createdBy(creator)
+                .build();
+
+        CareSubject savedCareSubject = careSubjectRepository.save(careSubject);
+
+        // 생성자를 PRIMARY 보호자로 자동 등록
+        Guardian primaryGuardian = Guardian.builder()
+                .user(creator)
+                .careSubject(savedCareSubject)
+                .role(GuardianRole.PRIMARY)
+                .status(GuardianStatus.ACCEPTED)
+                .invitedBy(creator)
+                .build();
+
+        primaryGuardian.setDefaultPermissions();
+        guardianRepository.save(primaryGuardian);
+
+        log.info("Created care subject: {} by user: {}", savedCareSubject.getName(), creator.getEmail());
+        return savedCareSubject;
+    }
+
+    /**
+     * 특정 사용자가 접근 가능한 케어 대상 목록 조회
+     */
+    public List<CareSubject> getAccessibleCareSubjects(Long userId) {
+        return careSubjectRepository.findAccessibleByUserId(userId);
+    }
+
+    /**
+     * 케어 대상 상세 조회
+     */
+    public CareSubject getCareSubject(Long careSubjectId, Long userId) {
+        return careSubjectRepository.findByIdAndAccessibleByUserId(careSubjectId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "케어 대상을 찾을 수 없거나 접근 권한이 없습니다."));
+    }
+
+    /**
+     * 케어 대상 정보 수정
+     */
+    @Transactional
+    public CareSubject updateCareSubject(Long careSubjectId, CareSubjectUpdateRequest request, Long userId) {
+        CareSubject careSubject = getCareSubject(careSubjectId, userId);
+
+        // 케어 대상 수정 권한 확인
+        Guardian userGuardian = guardianRepository.findByUserIdAndCareSubjectId(userId, careSubjectId)
+                .orElse(null);
+
+        // 생성자이거나 UPDATE_CARE_SUBJECT 권한이 있어야 함
+        boolean isCreator = careSubject.getCreatedBy().getId().equals(userId);
+        boolean hasUpdatePermission = userGuardian != null &&
+                userGuardian.hasPermission(Permission.UPDATE_CARE_SUBJECT);
+
+        if (!isCreator && !hasUpdatePermission) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "케어 대상 정보 수정 권한이 없습니다.");
+        }
+
+        // 정보 업데이트
+        if (request.getName() != null) {
+            careSubject.setName(request.getName());
+        }
+        if (request.getBloodType() != null) {
+            careSubject.setBloodType(request.getBloodType());
+        }
+        if (request.getBirthWeight() != null) {
+            careSubject.setBirthWeight(request.getBirthWeight());
+        }
+        if (request.getBirthHeight() != null) {
+            careSubject.setBirthHeight(request.getBirthHeight());
+        }
+        if (request.getProfileImageUrl() != null) {
+            careSubject.setProfileImageUrl(request.getProfileImageUrl());
+        }
+        if (request.getAdditionalInfo() != null) {
+            careSubject.setAdditionalInfo(request.getAdditionalInfo());
+        }
+
+        log.info("Updated care subject: {} by user: {}", careSubject.getName(), userId);
+        return careSubjectRepository.save(careSubject);
+    }
+
+    /**
+     * 케어 대상 삭제 (비활성화)
+     */
+    @Transactional
+    public void deleteCareSubject(Long careSubjectId, Long userId) {
+        CareSubject careSubject = getCareSubject(careSubjectId, userId);
+
+        // 케어 대상 삭제 권한 확인
+        Guardian userGuardian = guardianRepository.findByUserIdAndCareSubjectId(userId, careSubjectId)
+                .orElse(null);
+
+        // 생성자이거나 DELETE_CARE_SUBJECT 권한이 있어야 함
+        boolean isCreator = careSubject.getCreatedBy().getId().equals(userId);
+        boolean hasDeletePermission = userGuardian != null &&
+                userGuardian.hasPermission(Permission.DELETE_CARE_SUBJECT);
+
+        if (!isCreator && !hasDeletePermission) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "케어 대상 삭제 권한이 없습니다.");
+        }
+
+        careSubject.setIsActive(false);
+        careSubjectRepository.save(careSubject);
+
+        log.info("Deactivated care subject: {} by user: {}", careSubject.getName(), userId);
+    }
+
+    /**
+     * 케어 대상의 보호자 목록 조회
+     */
+    public List<Guardian> getCareSubjectGuardians(Long careSubjectId, Long userId) {
+        // 먼저 접근 권한 확인
+        getCareSubject(careSubjectId, userId);
+
+        return guardianRepository.findAcceptedByCareSubjectId(careSubjectId);
+    }
+
+    /**
+     * 특정 사용자의 보호자 관계 조회
+     */
+    public List<Guardian> getUserGuardianships(Long userId) {
+        return guardianRepository.findAcceptedByUserId(userId);
+    }
+
+    /**
+     * 특정 사용자의 대기 중인 초대 조회
+     */
+    public List<Guardian> getPendingInvitations(Long userId) {
+        return guardianRepository.findPendingByUserId(userId);
+    }
+}

--- a/src/main/java/carehub/domain/caresubject/CareSubjectType.java
+++ b/src/main/java/carehub/domain/caresubject/CareSubjectType.java
@@ -1,0 +1,17 @@
+package carehub.domain.caresubject;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CareSubjectType {
+    DEFAULT("일반", "일반 케어 대상"),
+    INFANT("신생아", "0-24개월 영아"),
+    CHILD("어린이", "2-12세 어린이"),
+    ELDERLY("노인", "노인 케어 대상"),
+    PET("반려동물", "반려동물");
+
+    private final String displayName;
+    private final String description;
+}

--- a/src/main/java/carehub/domain/caresubject/Gender.java
+++ b/src/main/java/carehub/domain/caresubject/Gender.java
@@ -1,0 +1,13 @@
+package carehub.domain.caresubject;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String description;
+}

--- a/src/main/java/carehub/domain/caresubject/Gender.java
+++ b/src/main/java/carehub/domain/caresubject/Gender.java
@@ -1,13 +1,48 @@
 package carehub.domain.caresubject;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum Gender {
-    MALE("남성"),
-    FEMALE("여성");
+    MALE("M", "남성"),
+    FEMALE("F", "여성"),
+    OTHER("O", "기타");
 
+    private final String code;
     private final String description;
+
+    @JsonValue
+    public String getCode() {
+        return this.code;
+    }
+
+    @JsonCreator
+    public static Gender fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (Gender gender : Gender.values()) {
+            if (gender.code.equals(code)) {
+                return gender;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown gender code: " + code + ". Valid codes are: M, F, O");
+    }
+
+    public static Gender fromCodeSafely(String code) {
+        try {
+            return fromCode(code);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public String getKoreanDescription() {
+        return this.description;
+    }
 }

--- a/src/main/java/carehub/domain/guardian/Guardian.java
+++ b/src/main/java/carehub/domain/guardian/Guardian.java
@@ -1,0 +1,134 @@
+package carehub.domain.guardian;
+
+import carehub.domain.caresubject.CareSubject;
+import carehub.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "guardians",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "care_subject_id"}),
+        indexes = {
+                @Index(name = "idx_guardian_user", columnList = "user_id"),
+                @Index(name = "idx_guardian_care_subject", columnList = "care_subject_id"),
+                @Index(name = "idx_guardian_status", columnList = "status")
+        })
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Guardian {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "care_subject_id", nullable = false)
+    @JsonBackReference
+    private CareSubject careSubject;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private GuardianRole role;
+
+    @Type(JsonType.class)
+    @Column(name = "permissions", columnDefinition = "jsonb")
+    @Builder.Default
+    private Map<String, Boolean> permissions = new HashMap<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private GuardianStatus status = GuardianStatus.PENDING;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by")
+    private User invitedBy;
+
+    @CreationTimestamp
+    @Column(name = "invited_at", nullable = false, updatable = false)
+    private LocalDateTime invitedAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "rejected_at")
+    private LocalDateTime rejectedAt;
+
+    @Column(name = "memo", length = 500)
+    private String memo;
+
+    public void acceptInvitation() {
+        this.status = GuardianStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+    }
+
+    public void rejectInvitation() {
+        this.status = GuardianStatus.REJECTED;
+        this.rejectedAt = LocalDateTime.now();
+    }
+
+    public void setDefaultPermissions() {
+        permissions.clear();
+
+        switch (role) {
+            case PRIMARY:
+                permissions.put(Permission.MANAGE_GUARDIANS.getKey(), true);
+                permissions.put(Permission.DELETE_CARE_SUBJECT.getKey(), true);
+                permissions.put(Permission.UPDATE_CARE_SUBJECT.getKey(), true);
+                permissions.put(Permission.RECORD_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.VIEW_ALL_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.MANAGE_SCHEDULE.getKey(), true);
+                permissions.put(Permission.MANAGE_HEALTH_DATA.getKey(), true);
+                permissions.put(Permission.MANAGE_DOCUMENTS.getKey(), true);
+                break;
+
+            case SECONDARY:
+                permissions.put(Permission.MANAGE_GUARDIANS.getKey(), false);
+                permissions.put(Permission.DELETE_CARE_SUBJECT.getKey(), false);
+                permissions.put(Permission.UPDATE_CARE_SUBJECT.getKey(), true);
+                permissions.put(Permission.RECORD_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.VIEW_ALL_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.MANAGE_SCHEDULE.getKey(), true);
+                permissions.put(Permission.MANAGE_HEALTH_DATA.getKey(), true);
+                permissions.put(Permission.MANAGE_DOCUMENTS.getKey(), true);
+                break;
+
+            case TEMPORARY:
+                // 임시 보호자는 기본 기록 권한만
+                permissions.put(Permission.MANAGE_GUARDIANS.getKey(), false);
+                permissions.put(Permission.DELETE_CARE_SUBJECT.getKey(), false);
+                permissions.put(Permission.UPDATE_CARE_SUBJECT.getKey(), false);
+                permissions.put(Permission.RECORD_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.VIEW_ALL_ACTIVITIES.getKey(), true);
+                permissions.put(Permission.MANAGE_SCHEDULE.getKey(), false);
+                permissions.put(Permission.MANAGE_HEALTH_DATA.getKey(), false);
+                permissions.put(Permission.MANAGE_DOCUMENTS.getKey(), false);
+                break;
+        }
+    }
+
+    public boolean hasPermission(String permission) {
+        return permissions.getOrDefault(permission, false);
+    }
+
+    public boolean hasPermission(Permission permission) {
+        return permissions.getOrDefault(permission.getKey(), false);
+    }
+}

--- a/src/main/java/carehub/domain/guardian/GuardianRepository.java
+++ b/src/main/java/carehub/domain/guardian/GuardianRepository.java
@@ -1,0 +1,62 @@
+package carehub.domain.guardian;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GuardianRepository extends JpaRepository<Guardian, Long> {
+
+    /**
+     * 특정 케어 대상의 모든 보호자 조회
+     */
+    List<Guardian> findByCareSubjectId(Long careSubjectId);
+
+    /**
+     * 특정 케어 대상의 승인된 보호자 조회
+     */
+    @Query("SELECT g FROM Guardian g WHERE g.careSubject.id = :careSubjectId AND g.status = 'ACCEPTED'")
+    List<Guardian> findAcceptedByCareSubjectId(@Param("careSubjectId") Long careSubjectId);
+
+    /**
+     * 특정 사용자의 보호자 관계 조회
+     */
+    List<Guardian> findByUserId(Long userId);
+
+    /**
+     * 특정 사용자의 승인된 보호자 관계 조회
+     */
+    @Query("SELECT g FROM Guardian g WHERE g.user.id = :userId AND g.status = 'ACCEPTED'")
+    List<Guardian> findAcceptedByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자의 대기 중인 초대 조회
+     */
+    @Query("SELECT g FROM Guardian g WHERE g.user.id = :userId AND g.status = 'PENDING'")
+    List<Guardian> findPendingByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자와 케어 대상의 보호자 관계 조회
+     */
+    Optional<Guardian> findByUserIdAndCareSubjectId(Long userId, Long careSubjectId);
+
+    /**
+     * 특정 케어 대상의 PRIMARY 보호자 조회
+     */
+    @Query("SELECT g FROM Guardian g WHERE g.careSubject.id = :careSubjectId AND g.role = 'PRIMARY' AND g.status = 'ACCEPTED'")
+    Optional<Guardian> findPrimaryByCareSubjectId(@Param("careSubjectId") Long careSubjectId);
+
+    /**
+     * 특정 사용자가 PRIMARY 보호자인지 확인
+     */
+    @Query("SELECT COUNT(g) > 0 FROM Guardian g WHERE g.user.id = :userId AND g.careSubject.id = :careSubjectId AND g.role = 'PRIMARY' AND g.status = 'ACCEPTED'")
+    boolean isPrimaryGuardian(@Param("userId") Long userId, @Param("careSubjectId") Long careSubjectId);
+
+    /**
+     * 특정 케어 대상에 대한 보호자 수 조회
+     */
+    @Query("SELECT COUNT(g) FROM Guardian g WHERE g.careSubject.id = :careSubjectId AND g.status = 'ACCEPTED'")
+    long countAcceptedByCareSubjectId(@Param("careSubjectId") Long careSubjectId);
+}

--- a/src/main/java/carehub/domain/guardian/GuardianRole.java
+++ b/src/main/java/carehub/domain/guardian/GuardianRole.java
@@ -1,0 +1,15 @@
+package carehub.domain.guardian;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GuardianRole {
+    PRIMARY("주 보호자"),
+    SECONDARY("부 보호자"),
+    TEMPORARY("임시 보호자"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/carehub/domain/guardian/GuardianService.java
+++ b/src/main/java/carehub/domain/guardian/GuardianService.java
@@ -1,0 +1,207 @@
+package carehub.domain.guardian;
+
+import carehub.common.exception.BusinessException;
+import carehub.common.exception.ErrorCode;
+import carehub.domain.caresubject.CareSubject;
+import carehub.domain.caresubject.CareSubjectRepository;
+import carehub.domain.user.User;
+import carehub.domain.user.UserRepository;
+import carehub.web.dto.guardian.GuardianInviteRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GuardianService {
+
+    private final GuardianRepository guardianRepository;
+    private final CareSubjectRepository careSubjectRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 보호자 초대
+     */
+    @Transactional
+    public Guardian inviteGuardian(GuardianInviteRequest request, Long inviterId) {
+        // 케어 대상 조회
+        CareSubject careSubject = careSubjectRepository.findByIdAndAccessibleByUserId(
+                        request.getCareSubjectId(), inviterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND,
+                        "케어 대상을 찾을 수 없거나 접근 권한이 없습니다."));
+
+        // 초대자 권한 확인 (PRIMARY 또는 SECONDARY만 초대 가능)
+        Guardian inviterGuardian = guardianRepository.findByUserIdAndCareSubjectId(inviterId, request.getCareSubjectId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACCESS_DENIED, "보호자 초대 권한이 없습니다."));
+
+        if (!inviterGuardian.hasPermission(Permission.MANAGE_GUARDIANS)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "보호자 초대 권한이 없습니다.");
+        }
+
+        // 초대받을 사용자 조회
+        User invitee = userRepository.findByEmail(request.getInviteeEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "초대할 사용자를 찾을 수 없습니다."));
+
+        // 이미 보호자 관계가 있는지 확인
+        if (guardianRepository.findByUserIdAndCareSubjectId(invitee.getId(), request.getCareSubjectId()).isPresent()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 보호자로 등록되어 있습니다.");
+        }
+
+        // PRIMARY 보호자는 하나만 가능
+        if (request.getRole() == GuardianRole.PRIMARY) {
+            if (guardianRepository.findPrimaryByCareSubjectId(request.getCareSubjectId()).isPresent()) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "주 보호자는 한 명만 등록 가능합니다.");
+            }
+        }
+
+        // 보호자 초대 생성
+        Guardian guardian = Guardian.builder()
+                .user(invitee)
+                .careSubject(careSubject)
+                .role(request.getRole())
+                .status(GuardianStatus.PENDING)
+                .invitedBy(inviterGuardian.getUser())
+                .memo(request.getMemo())
+                .build();
+
+        guardian.setDefaultPermissions();
+        Guardian savedGuardian = guardianRepository.save(guardian);
+
+        // TODO: 이메일 알림 발송
+        log.info("Guardian invitation created: {} invited {} for care subject: {}",
+                inviterGuardian.getUser().getEmail(), invitee.getEmail(), careSubject.getName());
+
+        return savedGuardian;
+    }
+
+    /**
+     * 보호자 초대 수락
+     */
+    @Transactional
+    public Guardian acceptInvitation(Long guardianId, Long userId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "초대를 찾을 수 없습니다."));
+
+        // 본인의 초대인지 확인
+        if (!guardian.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "본인의 초대만 처리할 수 있습니다.");
+        }
+
+        // 대기 상태인지 확인
+        if (guardian.getStatus() != GuardianStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 처리된 초대입니다.");
+        }
+
+        guardian.acceptInvitation();
+        Guardian savedGuardian = guardianRepository.save(guardian);
+
+        log.info("Guardian invitation accepted: {} for care subject: {}",
+                guardian.getUser().getEmail(), guardian.getCareSubject().getName());
+
+        return savedGuardian;
+    }
+
+    /**
+     * 보호자 초대 거절
+     */
+    @Transactional
+    public Guardian rejectInvitation(Long guardianId, Long userId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "초대를 찾을 수 없습니다."));
+
+        // 본인의 초대인지 확인
+        if (!guardian.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "본인의 초대만 처리할 수 있습니다.");
+        }
+
+        // 대기 상태인지 확인
+        if (guardian.getStatus() != GuardianStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 처리된 초대입니다.");
+        }
+
+        guardian.rejectInvitation();
+        Guardian savedGuardian = guardianRepository.save(guardian);
+
+        log.info("Guardian invitation rejected: {} for care subject: {}",
+                guardian.getUser().getEmail(), guardian.getCareSubject().getName());
+
+        return savedGuardian;
+    }
+
+    /**
+     * 보호자 권한 수정
+     */
+    @Transactional
+    public Guardian updateGuardianRole(Long guardianId, GuardianRole newRole, Long userId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "보호자를 찾을 수 없습니다."));
+
+        // 권한 확인 (PRIMARY 보호자만 권한 수정 가능)
+        if (!guardianRepository.isPrimaryGuardian(userId, guardian.getCareSubject().getId())) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "보호자 권한 수정 권한이 없습니다.");
+        }
+
+        // PRIMARY 보호자는 하나만 가능
+        if (newRole == GuardianRole.PRIMARY && guardian.getRole() != GuardianRole.PRIMARY) {
+            if (guardianRepository.findPrimaryByCareSubjectId(guardian.getCareSubject().getId()).isPresent()) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "주 보호자는 한 명만 등록 가능합니다.");
+            }
+        }
+
+        guardian.setRole(newRole);
+        guardian.setDefaultPermissions();
+        Guardian savedGuardian = guardianRepository.save(guardian);
+
+        log.info("Guardian role updated: {} to {} for care subject: {}",
+                guardian.getUser().getEmail(), newRole, guardian.getCareSubject().getName());
+
+        return savedGuardian;
+    }
+
+    /**
+     * 보호자 제거
+     */
+    @Transactional
+    public void removeGuardian(Long guardianId, Long userId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "보호자를 찾을 수 없습니다."));
+
+        // 권한 확인 (PRIMARY 보호자만 제거 가능, 또는 본인)
+        boolean isPrimary = guardianRepository.isPrimaryGuardian(userId, guardian.getCareSubject().getId());
+        boolean isSelf = guardian.getUser().getId().equals(userId);
+
+        if (!isPrimary && !isSelf) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "보호자 제거 권한이 없습니다.");
+        }
+
+        // PRIMARY 보호자는 자신을 제거할 수 없음 (다른 PRIMARY가 있을 때만 가능)
+        if (guardian.getRole() == GuardianRole.PRIMARY && isSelf) {
+            long primaryCount = guardianRepository.countAcceptedByCareSubjectId(guardian.getCareSubject().getId());
+            if (primaryCount <= 1) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "최소 한 명의 주 보호자가 필요합니다.");
+            }
+        }
+
+        guardianRepository.delete(guardian);
+
+        log.info("Guardian removed: {} from care subject: {}",
+                guardian.getUser().getEmail(), guardian.getCareSubject().getName());
+    }
+
+    /**
+     * 특정 케어 대상의 보호자 목록 조회
+     */
+    public List<Guardian> getGuardiansByCareSubject(Long careSubjectId, Long userId) {
+        // 접근 권한 확인
+        careSubjectRepository.findByIdAndAccessibleByUserId(careSubjectId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND,
+                        "케어 대상을 찾을 수 없거나 접근 권한이 없습니다."));
+
+        return guardianRepository.findAcceptedByCareSubjectId(careSubjectId);
+    }
+}

--- a/src/main/java/carehub/domain/guardian/GuardianStatus.java
+++ b/src/main/java/carehub/domain/guardian/GuardianStatus.java
@@ -1,0 +1,14 @@
+package carehub.domain.guardian;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GuardianStatus {
+    PENDING("초대 대기"),
+    ACCEPTED("수락됨"),
+    REJECTED("거절됨");
+
+    private final String description;
+}

--- a/src/main/java/carehub/domain/guardian/Permission.java
+++ b/src/main/java/carehub/domain/guardian/Permission.java
@@ -1,0 +1,34 @@
+package carehub.domain.guardian;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Permission {
+    // 보호자 관리 권한
+    MANAGE_GUARDIANS("보호자 관리"),
+
+    // 케어 대상 관리 권한
+    DELETE_CARE_SUBJECT("케어 대상 삭제"),
+    UPDATE_CARE_SUBJECT("케어 대상 수정"),
+
+    // 케어 활동 권한
+    RECORD_ACTIVITIES("케어 활동 기록"),
+    VIEW_ALL_ACTIVITIES("모든 케어 활동 조회"),
+
+    // 일정 관리 권한
+    MANAGE_SCHEDULE("일정 관리"),
+
+    // 건강 데이터 권한
+    MANAGE_HEALTH_DATA("건강 데이터 관리"),
+
+    // 문서 관리 권한
+    MANAGE_DOCUMENTS("문서 관리");
+
+    private final String description;
+
+    public String getKey() {
+        return this.name();
+    }
+}

--- a/src/main/java/carehub/web/controller/BaseController.java
+++ b/src/main/java/carehub/web/controller/BaseController.java
@@ -1,0 +1,59 @@
+package carehub.web.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public abstract class BaseController {
+
+    /**
+     * 현재 로그인한 사용자 ID 조회
+     * @return 사용자 ID
+     * @throws RuntimeException 인증되지 않은 경우
+     */
+    protected Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new RuntimeException("인증되지 않은 사용자입니다.");
+        }
+
+        if (authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.User) {
+            org.springframework.security.core.userdetails.User principal =
+                    (org.springframework.security.core.userdetails.User) authentication.getPrincipal();
+
+            try {
+                return Long.parseLong(principal.getUsername());
+            } catch (NumberFormatException e) {
+                throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + principal.getUsername());
+            }
+        }
+
+        throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다.");
+    }
+
+    /**
+     * 현재 로그인한 사용자 이메일 조회 (필요시 사용)
+     * @return 사용자 이메일
+     */
+    protected String getCurrentUserEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getName() != null) {
+            return authentication.getName();
+        }
+
+        throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다.");
+    }
+
+    /**
+     * 인증 여부 확인
+     * @return 인증 여부
+     */
+    protected boolean isAuthenticated() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal());
+    }
+}

--- a/src/main/java/carehub/web/controller/CareSubjectController.java
+++ b/src/main/java/carehub/web/controller/CareSubjectController.java
@@ -1,0 +1,137 @@
+package carehub.web.controller;
+
+import carehub.common.dto.response.ApiResponse;
+import carehub.domain.caresubject.*;
+import carehub.domain.guardian.Guardian;
+import carehub.web.dto.caresubject.CareSubjectCreateRequest;
+import carehub.web.dto.caresubject.CareSubjectResponse;
+import carehub.web.dto.caresubject.CareSubjectUpdateRequest;
+import carehub.web.dto.guardian.GuardianResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/care-subjects")
+@RequiredArgsConstructor
+public class CareSubjectController extends BaseController {
+
+    private final CareSubjectService careSubjectService;
+
+    /**
+     * 케어 대상 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CareSubjectResponse>> createCareSubject(
+            @Valid @RequestBody CareSubjectCreateRequest request) {
+
+        Long userId = getCurrentUserId();
+        CareSubject careSubject = careSubjectService.createCareSubject(request, userId);
+        CareSubjectResponse response = CareSubjectResponse.from(careSubject);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내가 접근 가능한 케어 대상 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CareSubjectResponse>>> getMyCareSubjects() {
+        Long userId = getCurrentUserId();
+        List<CareSubject> careSubjects = careSubjectService.getAccessibleCareSubjects(userId);
+        List<CareSubjectResponse> responses = careSubjects.stream()
+                .map(CareSubjectResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * 케어 대상 상세 조회
+     */
+    @GetMapping("/{careSubjectId}")
+    public ResponseEntity<ApiResponse<CareSubjectResponse>> getCareSubject(
+            @PathVariable Long careSubjectId) {
+
+        Long userId = getCurrentUserId();
+        CareSubject careSubject = careSubjectService.getCareSubject(careSubjectId, userId);
+        CareSubjectResponse response = CareSubjectResponse.from(careSubject);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 케어 대상 정보 수정
+     */
+    @PutMapping("/{careSubjectId}")
+    public ResponseEntity<ApiResponse<CareSubjectResponse>> updateCareSubject(
+            @PathVariable Long careSubjectId,
+            @Valid @RequestBody CareSubjectUpdateRequest request) {
+
+        Long userId = getCurrentUserId();
+        CareSubject careSubject = careSubjectService.updateCareSubject(careSubjectId, request, userId);
+        CareSubjectResponse response = CareSubjectResponse.from(careSubject);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 케어 대상 삭제 (비활성화)
+     */
+    @DeleteMapping("/{careSubjectId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCareSubject(@PathVariable Long careSubjectId) {
+        Long userId = getCurrentUserId();
+        careSubjectService.deleteCareSubject(careSubjectId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 케어 대상의 보호자 목록 조회
+     */
+    @GetMapping("/{careSubjectId}/guardians")
+    public ResponseEntity<ApiResponse<List<GuardianResponse>>> getCareSubjectGuardians(
+            @PathVariable Long careSubjectId) {
+
+        Long userId = getCurrentUserId();
+        List<Guardian> guardians = careSubjectService.getCareSubjectGuardians(careSubjectId, userId);
+        List<GuardianResponse> responses = guardians.stream()
+                .map(GuardianResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * 내 보호자 관계 목록 조회
+     */
+    @GetMapping("/my-guardianships")
+    public ResponseEntity<ApiResponse<List<GuardianResponse>>> getMyGuardianships() {
+        Long userId = getCurrentUserId();
+        List<Guardian> guardians = careSubjectService.getUserGuardianships(userId);
+        List<GuardianResponse> responses = guardians.stream()
+                .map(GuardianResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * 내 대기 중인 초대 목록 조회
+     */
+    @GetMapping("/pending-invitations")
+    public ResponseEntity<ApiResponse<List<GuardianResponse>>> getPendingInvitations() {
+        Long userId = getCurrentUserId();
+        List<Guardian> guardians = careSubjectService.getPendingInvitations(userId);
+        List<GuardianResponse> responses = guardians.stream()
+                .map(GuardianResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+}

--- a/src/main/java/carehub/web/controller/GuardianController.java
+++ b/src/main/java/carehub/web/controller/GuardianController.java
@@ -1,0 +1,108 @@
+package carehub.web.controller;
+
+import carehub.common.dto.response.ApiResponse;
+import carehub.domain.guardian.*;
+import carehub.web.dto.guardian.GuardianInviteRequest;
+import carehub.web.dto.guardian.GuardianResponse;
+import carehub.web.dto.guardian.GuardianRoleUpdateRequest;
+import carehub.web.dto.guardian.InvitationResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/guardians")
+@RequiredArgsConstructor
+public class GuardianController extends BaseController {
+
+    private final GuardianService guardianService;
+
+    /**
+     * 보호자 초대
+     */
+    @PostMapping("/invite")
+    public ResponseEntity<ApiResponse<GuardianResponse>> inviteGuardian(
+            @Valid @RequestBody GuardianInviteRequest request) {
+
+        Long userId = getCurrentUserId();
+        Guardian guardian = guardianService.inviteGuardian(request, userId);
+        GuardianResponse response = GuardianResponse.from(guardian);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 보호자 초대 수락
+     */
+    @PostMapping("/{guardianId}/accept")
+    public ResponseEntity<ApiResponse<InvitationResponse>> acceptInvitation(
+            @PathVariable Long guardianId) {
+
+        Long userId = getCurrentUserId();
+        Guardian guardian = guardianService.acceptInvitation(guardianId, userId);
+        InvitationResponse response = InvitationResponse.accepted(guardian.getId());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 보호자 초대 거절
+     */
+    @PostMapping("/{guardianId}/reject")
+    public ResponseEntity<ApiResponse<InvitationResponse>> rejectInvitation(
+            @PathVariable Long guardianId) {
+
+        Long userId = getCurrentUserId();
+        Guardian guardian = guardianService.rejectInvitation(guardianId, userId);
+        InvitationResponse response = InvitationResponse.rejected(guardian.getId());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 보호자 권한 수정
+     */
+    @PutMapping("/{guardianId}/role")
+    public ResponseEntity<ApiResponse<GuardianResponse>> updateGuardianRole(
+            @PathVariable Long guardianId,
+            @Valid @RequestBody GuardianRoleUpdateRequest request) {
+
+        Long userId = getCurrentUserId();
+        Guardian guardian = guardianService.updateGuardianRole(guardianId, request.getNewRole(), userId);
+        GuardianResponse response = GuardianResponse.from(guardian);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 보호자 제거
+     */
+    @DeleteMapping("/{guardianId}")
+    public ResponseEntity<ApiResponse<Void>> removeGuardian(@PathVariable Long guardianId) {
+        Long userId = getCurrentUserId();
+        guardianService.removeGuardian(guardianId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 특정 케어 대상의 보호자 목록 조회
+     */
+    @GetMapping("/care-subject/{careSubjectId}")
+    public ResponseEntity<ApiResponse<List<GuardianResponse>>> getGuardiansByCareSubject(
+            @PathVariable Long careSubjectId) {
+
+        Long userId = getCurrentUserId();
+        List<Guardian> guardians = guardianService.getGuardiansByCareSubject(careSubjectId, userId);
+        List<GuardianResponse> responses = guardians.stream()
+                .map(GuardianResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+}

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectCreateRequest.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectCreateRequest.java
@@ -1,0 +1,39 @@
+package carehub.web.dto.caresubject;
+
+import carehub.domain.caresubject.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+// 케어 대상 생성 요청 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareSubjectCreateRequest {
+
+    @NotBlank(message = "이름은 필수입니다")
+    private String name;
+
+    @NotNull(message = "생년월일은 필수입니다")
+    @Past(message = "생년월일은 과거 날짜여야 합니다")
+    private LocalDate birthDate;
+
+    @NotNull(message = "성별은 필수입니다")
+    private Gender gender;
+
+    private String bloodType;
+    private BigDecimal birthWeight;
+    private BigDecimal birthHeight;
+    private String profileImageUrl;
+    private Map<String, Object> additionalInfo;
+}
+

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectCreateRequest.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectCreateRequest.java
@@ -8,12 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
 
-// 케어 대상 생성 요청 DTO
+@Slf4j
 @Data
 @Builder
 @NoArgsConstructor
@@ -27,13 +28,110 @@ public class CareSubjectCreateRequest {
     @Past(message = "생년월일은 과거 날짜여야 합니다")
     private LocalDate birthDate;
 
-    @NotNull(message = "성별은 필수입니다")
     private Gender gender;
 
     private String bloodType;
-    private BigDecimal birthWeight;
-    private BigDecimal birthHeight;
-    private String profileImageUrl;
-    private Map<String, Object> additionalInfo;
-}
 
+    private BigDecimal birthWeight;
+
+    private BigDecimal birthHeight;
+
+    private String profileImageUrl;
+
+    private Map<String, Object> additionalInfo;
+
+    private Integer birthWeightGrams;
+
+    private Integer birthHeightCm;
+
+    private Integer headCircumferenceCm;
+
+    private Integer gestationalAgeWeeks;
+
+    private String deliveryType;
+
+    private String allergies;
+
+    private String specialCareNeeds;
+
+    private LocalDate lastCheckupDate;
+
+    @Override
+    public String toString() {
+        return "CareSubjectCreateRequest{" +
+                "name='" + name + '\'' +
+                ", birthDate=" + birthDate +
+                ", gender=" + (gender != null ? gender.getCode() : "null") +
+                ", bloodType='" + bloodType + '\'' +
+                ", birthWeight=" + birthWeight +
+                ", birthHeight=" + birthHeight +
+                ", profileImageUrl='" + (profileImageUrl != null ? "있음" : "없음") + '\'' +
+                ", additionalInfo=" + (additionalInfo != null ? additionalInfo.size() + "개 항목" : "없음") +
+                ", birthWeightGrams=" + birthWeightGrams +
+                ", birthHeightCm=" + birthHeightCm +
+                ", headCircumferenceCm=" + headCircumferenceCm +
+                ", gestationalAgeWeeks=" + gestationalAgeWeeks +
+                ", deliveryType='" + deliveryType + '\'' +
+                ", allergies='" + allergies + '\'' +
+                ", specialCareNeeds='" + specialCareNeeds + '\'' +
+                ", lastCheckupDate=" + lastCheckupDate +
+                '}';
+    }
+
+    public void validateRequest() {
+        log.debug("케어 대상 생성 요청 유효성 검증 시작");
+
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("이름은 필수입니다");
+        }
+
+        if (birthDate == null) {
+            throw new IllegalArgumentException("생년월일은 필수입니다");
+        }
+
+        if (birthDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("생년월일은 과거 날짜여야 합니다");
+        }
+
+        // 신생아 특화 필드 검증
+        if (birthWeightGrams != null && birthWeightGrams <= 0) {
+            throw new IllegalArgumentException("출생 체중은 0보다 커야 합니다");
+        }
+
+        if (birthHeightCm != null && birthHeightCm <= 0) {
+            throw new IllegalArgumentException("출생 신장은 0보다 커야 합니다");
+        }
+
+        if (gestationalAgeWeeks != null && (gestationalAgeWeeks < 20 || gestationalAgeWeeks > 45)) {
+            throw new IllegalArgumentException("재태 기간은 20-45주 사이여야 합니다");
+        }
+
+        log.debug("케어 대상 생성 요청 유효성 검증 완료");
+    }
+
+    public void cleanEmptyFields() {
+        log.debug("빈 문자열 필드 정리 시작");
+
+        if (bloodType != null && bloodType.trim().isEmpty()) {
+            bloodType = null;
+        }
+
+        if (profileImageUrl != null && profileImageUrl.trim().isEmpty()) {
+            profileImageUrl = null;
+        }
+
+        if (deliveryType != null && deliveryType.trim().isEmpty()) {
+            deliveryType = null;
+        }
+
+        if (allergies != null && allergies.trim().isEmpty()) {
+            allergies = null;
+        }
+
+        if (specialCareNeeds != null && specialCareNeeds.trim().isEmpty()) {
+            specialCareNeeds = null;
+        }
+
+        log.debug("빈 문자열 필드 정리 완료");
+    }
+}

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
@@ -37,14 +37,22 @@ public class CareSubjectResponse {
     // 계산된 필드
     private int ageInMonths;
     private long ageInDays;
+    private Integer ageYears;
+    private Integer ageDays;
 
     // 생성자 정보
     private String createdByName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    // 임시: 프론트엔드 호환성을 위한 주 보호자 정보 (실제로는 createdBy와 동일)
+    private MainCaregiverInfo mainCaregiver;
+
     // 보호자 목록 (간단한 정보만)
     private List<GuardianSummary> guardians;
+
+    // 추가 보호자 목록 (PRIMARY 보호자 제외한 나머지)
+    private List<CaregiverInfo> caregivers;
 
     // 신생아 전용 필드들
     private Integer birthWeightGrams;
@@ -60,12 +68,34 @@ public class CareSubjectResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class MainCaregiverInfo {
+        private Long id;
+        private String name;
+        private String email;
+        private String profileImageUrl;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class GuardianSummary {
         private Long id;
         private String userName;
         private String userEmail;
         private String role;
         private String status;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CaregiverInfo {
+        private Long id;
+        private String name;
+        private String email;
+        private String profileImageUrl;
     }
 
     public static CareSubjectResponse from(CareSubject careSubject) {
@@ -78,6 +108,26 @@ public class CareSubjectResponse {
                         .status(guardian.getStatus().name())
                         .build())
                 .toList();
+
+        // 추가 보호자 목록 (PRIMARY 제외)
+        List<CaregiverInfo> caregivers = careSubject.getGuardians().stream()
+                .filter(guardian -> guardian.getRole() != carehub.domain.guardian.GuardianRole.PRIMARY)
+                .filter(guardian -> guardian.getStatus() == carehub.domain.guardian.GuardianStatus.ACCEPTED)
+                .map(guardian -> CaregiverInfo.builder()
+                        .id(guardian.getUser().getId())
+                        .name(guardian.getUser().getName())
+                        .email(guardian.getUser().getEmail())
+                        .profileImageUrl(guardian.getUser().getProfileImageUrl())
+                        .build())
+                .toList();
+
+        // 임시: mainCaregiver는 createdBy와 동일하게 설정 (프론트엔드 호환성 유지)
+        MainCaregiverInfo mainCaregiver = MainCaregiverInfo.builder()
+                .id(careSubject.getCreatedBy().getId())
+                .name(careSubject.getCreatedBy().getName())
+                .email(careSubject.getCreatedBy().getEmail())
+                .profileImageUrl(careSubject.getCreatedBy().getProfileImageUrl())
+                .build();
 
         return CareSubjectResponse.builder()
                 .id(careSubject.getId())
@@ -93,10 +143,14 @@ public class CareSubjectResponse {
                 .subjectType(careSubject.getSubjectType())
                 .ageInMonths(careSubject.getAgeInMonths())
                 .ageInDays(careSubject.getAgeInDays())
+                .ageYears(careSubject.getAgeInMonths() / 12) // 년 단위 나이 계산
+                .ageDays((int) careSubject.getAgeInDays()) // int 타입으로 변환
                 .createdByName(careSubject.getCreatedBy().getName())
                 .createdAt(careSubject.getCreatedAt())
                 .updatedAt(careSubject.getUpdatedAt())
+                .mainCaregiver(mainCaregiver) // 임시: createdBy 정보 사용
                 .guardians(guardianSummaries)
+                .caregivers(caregivers)
                 // 신생아 전용 필드들
                 .birthWeightGrams(careSubject.getBirthWeightGrams())
                 .birthHeightCm(careSubject.getBirthHeightCm())

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
@@ -1,7 +1,7 @@
 package carehub.web.dto.caresubject;
 
-
 import carehub.domain.caresubject.CareSubject;
+import carehub.domain.caresubject.CareSubjectType;
 import carehub.domain.caresubject.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,6 +31,9 @@ public class CareSubjectResponse {
     private Map<String, Object> additionalInfo;
     private Boolean isActive;
 
+    // 케어 대상 타입
+    private CareSubjectType subjectType;
+
     // 계산된 필드
     private int ageInMonths;
     private long ageInDays;
@@ -42,6 +45,16 @@ public class CareSubjectResponse {
 
     // 보호자 목록 (간단한 정보만)
     private List<GuardianSummary> guardians;
+
+    // 신생아 전용 필드들
+    private Integer birthWeightGrams;
+    private Integer birthHeightCm;
+    private Integer headCircumferenceCm;
+    private Integer gestationalAgeWeeks;
+    private String deliveryType;
+    private String allergies;
+    private String specialCareNeeds;
+    private LocalDate lastCheckupDate;
 
     @Data
     @Builder
@@ -77,12 +90,22 @@ public class CareSubjectResponse {
                 .profileImageUrl(careSubject.getProfileImageUrl())
                 .additionalInfo(careSubject.getAdditionalInfo())
                 .isActive(careSubject.getIsActive())
+                .subjectType(careSubject.getSubjectType())
                 .ageInMonths(careSubject.getAgeInMonths())
                 .ageInDays(careSubject.getAgeInDays())
                 .createdByName(careSubject.getCreatedBy().getName())
                 .createdAt(careSubject.getCreatedAt())
                 .updatedAt(careSubject.getUpdatedAt())
                 .guardians(guardianSummaries)
+                // 신생아 전용 필드들
+                .birthWeightGrams(careSubject.getBirthWeightGrams())
+                .birthHeightCm(careSubject.getBirthHeightCm())
+                .headCircumferenceCm(careSubject.getHeadCircumferenceCm())
+                .gestationalAgeWeeks(careSubject.getGestationalAgeWeeks())
+                .deliveryType(careSubject.getDeliveryType())
+                .allergies(careSubject.getAllergies())
+                .specialCareNeeds(careSubject.getSpecialCareNeeds())
+                .lastCheckupDate(careSubject.getLastCheckupDate())
                 .build();
     }
 }

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectResponse.java
@@ -1,0 +1,88 @@
+package carehub.web.dto.caresubject;
+
+
+import carehub.domain.caresubject.CareSubject;
+import carehub.domain.caresubject.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+// 케어 대상 응답 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareSubjectResponse {
+    private Long id;
+    private String name;
+    private LocalDate birthDate;
+    private Gender gender;
+    private String bloodType;
+    private BigDecimal birthWeight;
+    private BigDecimal birthHeight;
+    private String profileImageUrl;
+    private Map<String, Object> additionalInfo;
+    private Boolean isActive;
+
+    // 계산된 필드
+    private int ageInMonths;
+    private long ageInDays;
+
+    // 생성자 정보
+    private String createdByName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // 보호자 목록 (간단한 정보만)
+    private List<GuardianSummary> guardians;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GuardianSummary {
+        private Long id;
+        private String userName;
+        private String userEmail;
+        private String role;
+        private String status;
+    }
+
+    public static CareSubjectResponse from(CareSubject careSubject) {
+        List<GuardianSummary> guardianSummaries = careSubject.getGuardians().stream()
+                .map(guardian -> GuardianSummary.builder()
+                        .id(guardian.getId())
+                        .userName(guardian.getUser().getName())
+                        .userEmail(guardian.getUser().getEmail())
+                        .role(guardian.getRole().name())
+                        .status(guardian.getStatus().name())
+                        .build())
+                .toList();
+
+        return CareSubjectResponse.builder()
+                .id(careSubject.getId())
+                .name(careSubject.getName())
+                .birthDate(careSubject.getBirthDate())
+                .gender(careSubject.getGender())
+                .bloodType(careSubject.getBloodType())
+                .birthWeight(careSubject.getBirthWeight())
+                .birthHeight(careSubject.getBirthHeight())
+                .profileImageUrl(careSubject.getProfileImageUrl())
+                .additionalInfo(careSubject.getAdditionalInfo())
+                .isActive(careSubject.getIsActive())
+                .ageInMonths(careSubject.getAgeInMonths())
+                .ageInDays(careSubject.getAgeInDays())
+                .createdByName(careSubject.getCreatedBy().getName())
+                .createdAt(careSubject.getCreatedAt())
+                .updatedAt(careSubject.getUpdatedAt())
+                .guardians(guardianSummaries)
+                .build();
+    }
+}

--- a/src/main/java/carehub/web/dto/caresubject/CareSubjectUpdateRequest.java
+++ b/src/main/java/carehub/web/dto/caresubject/CareSubjectUpdateRequest.java
@@ -1,0 +1,23 @@
+package carehub.web.dto.caresubject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+// 케어 대상 수정 요청 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareSubjectUpdateRequest {
+    private String name;
+    private String bloodType;
+    private BigDecimal birthWeight;
+    private BigDecimal birthHeight;
+    private String profileImageUrl;
+    private Map<String, Object> additionalInfo;
+}

--- a/src/main/java/carehub/web/dto/guardian/GuardianInviteRequest.java
+++ b/src/main/java/carehub/web/dto/guardian/GuardianInviteRequest.java
@@ -1,0 +1,29 @@
+package carehub.web.dto.guardian;
+
+import carehub.domain.guardian.GuardianRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 보호자 초대 요청 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuardianInviteRequest {
+
+    @NotNull(message = "케어 대상 ID는 필수입니다")
+    private Long careSubjectId;
+
+    @NotNull(message = "초대할 사용자 이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String inviteeEmail;
+
+    @NotNull(message = "보호자 역할은 필수입니다")
+    private GuardianRole role;
+
+    private String memo;
+}

--- a/src/main/java/carehub/web/dto/guardian/GuardianResponse.java
+++ b/src/main/java/carehub/web/dto/guardian/GuardianResponse.java
@@ -1,0 +1,64 @@
+package carehub.web.dto.guardian;
+
+import carehub.domain.guardian.Guardian;
+import carehub.domain.guardian.GuardianRole;
+import carehub.domain.guardian.GuardianStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuardianResponse {
+    private Long id;
+
+    // 사용자 정보
+    private Long userId;
+    private String userName;
+    private String userEmail;
+    private String userProfileImageUrl;
+
+    // 케어 대상 정보
+    private Long careSubjectId;
+    private String careSubjectName;
+
+    // 보호자 정보
+    private GuardianRole role;
+    private GuardianStatus status;
+    private Map<String, Boolean> permissions;
+
+    // 초대 정보
+    private String invitedByName;
+    private String invitedByEmail;
+    private LocalDateTime invitedAt;
+    private LocalDateTime acceptedAt;
+    private LocalDateTime rejectedAt;
+    private String memo;
+
+    public static GuardianResponse from(Guardian guardian) {
+        return GuardianResponse.builder()
+                .id(guardian.getId())
+                .userId(guardian.getUser().getId())
+                .userName(guardian.getUser().getName())
+                .userEmail(guardian.getUser().getEmail())
+                .userProfileImageUrl(guardian.getUser().getProfileImageUrl())
+                .careSubjectId(guardian.getCareSubject().getId())
+                .careSubjectName(guardian.getCareSubject().getName())
+                .role(guardian.getRole())
+                .status(guardian.getStatus())
+                .permissions(guardian.getPermissions())
+                .invitedByName(guardian.getInvitedBy() != null ? guardian.getInvitedBy().getName() : null)
+                .invitedByEmail(guardian.getInvitedBy() != null ? guardian.getInvitedBy().getEmail() : null)
+                .invitedAt(guardian.getInvitedAt())
+                .acceptedAt(guardian.getAcceptedAt())
+                .rejectedAt(guardian.getRejectedAt())
+                .memo(guardian.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/carehub/web/dto/guardian/GuardianRoleUpdateRequest.java
+++ b/src/main/java/carehub/web/dto/guardian/GuardianRoleUpdateRequest.java
@@ -1,0 +1,18 @@
+package carehub.web.dto.guardian;
+
+import carehub.domain.guardian.GuardianRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+
+// 보호자 권한 수정 요청 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuardianRoleUpdateRequest {
+    @NotNull
+    private GuardianRole newRole;
+}

--- a/src/main/java/carehub/web/dto/guardian/InvitationResponse.java
+++ b/src/main/java/carehub/web/dto/guardian/InvitationResponse.java
@@ -1,0 +1,33 @@
+package carehub.web.dto.guardian;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 초대 처리 응답 DTO
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationResponse {
+    private Long guardianId;
+    private String status;
+    private String message;
+
+    public static InvitationResponse accepted(Long guardianId) {
+        return InvitationResponse.builder()
+                .guardianId(guardianId)
+                .status("ACCEPTED")
+                .message("초대를 수락했습니다.")
+                .build();
+    }
+
+    public static InvitationResponse rejected(Long guardianId) {
+        return InvitationResponse.builder()
+                .guardianId(guardianId)
+                .status("REJECTED")
+                .message("초대를 거절했습니다.")
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,26 @@
 spring:
   profiles:
     active: dev, email
+
+  # Jackson 설정
+  jackson:
+    # 빈 문자열을 null로 처리
+    deserialization:
+      accept-empty-string-as-null-object: true
+      accept-empty-array-as-null-object: true
+      accept-single-value-as-array: true
+      fail-on-unknown-properties: false
+      fail-on-null-for-primitives: false
+    # 날짜 관련 설정
+    serialization:
+      write-dates-as-timestamps: false
+      fail-on-empty-beans: false
+    # 기본 프로퍼티 포함 설정
+    default-property-inclusion: non_null
+    # 날짜 형식 설정
+    date-format: "yyyy-MM-dd"
+    time-zone: "Asia/Seoul"
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -8,7 +28,56 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        # SQL 파라미터 로깅 활성화
+        show_sql: true
+        type:
+          descriptor:
+            sql: trace
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+# 로깅 레벨 설정
 logging:
   level:
+    # 루트 로깅 레벨
+    root: INFO
+
+    # Spring Web 관련 로깅
+    org.springframework.web: DEBUG
+    org.springframework.web.servlet.DispatcherServlet: DEBUG
+    org.springframework.web.servlet.mvc.method.annotation: DEBUG
+
+    # Hibernate/JPA 관련 로깅
+    org.hibernate: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.hibernate.engine.QueryParameters: DEBUG
+    org.hibernate.engine.query.HQLQueryPlan: DEBUG
+
+    # Spring Security 로깅
+    org.springframework.security: DEBUG
+
+    # RestTemplate 로깅
     org.springframework.web.client.RestTemplate: DEBUG
+
+    # 애플리케이션 패키지 로깅
+    carehub: DEBUG
+
+    # 스프링 부트 관련
+    org.springframework.boot.autoconfigure: DEBUG
+
+    # 트랜잭션 로깅
+    org.springframework.transaction: DEBUG
+
+    # Bean 생성 관련
+    org.springframework.beans: DEBUG
+
+    # AOP 관련
+    org.springframework.aop: DEBUG
+
+    # Jackson 관련 로깅
+    com.fasterxml.jackson: DEBUG
+
+  # 로그 패턴 설정
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
## 변경 사항
- 케어 대상 생성 API (`/api/v1/care-subjects`) 구현
- 케어 대상 목록 조회 API (`/api/v1/care-subjects`) 추가
- 케어 대상 상세 조회 API (`/api/v1/care-subjects/{id}`) 개발
- 케어 대상 수정 API (`/api/v1/care-subjects/{id}`) 구현
- 케어 대상 삭제 API (`/api/v1/care-subjects/{id}`) 추가
- 보호자 권한 관리 시스템 및 초대 기능 구현
- 신생아 프로필 특화 필드 지원
- 케어 대상 유형 자동 분류 로직 추가

## 주요 기능
- 다중 보호자 시스템을 통한 협업 케어 관리
- 신생아 전용 데이터 필드 (출생 체중, 신장, 재태기간 등)
- 역할 기반 권한 제어 (PRIMARY, SECONDARY, TEMPORARY)
- PostgreSQL JSONB를 활용한 확장 가능한 데이터 구조
- 보호자 초대 및 승인 워크플로우
- 케어 대상별 접근 권한 관리
- 자동 나이 계산 및 발달 단계 추적

## 테스트 방법
1. 회원가입/로그인 후 케어 대상 생성 시도
2. 신생아 프로필 생성 시 특화 필드 입력 확인
3. 다른 사용자 초대 및 권한 설정 테스트
4. 케어 대상 수정/삭제 권한 검증
5. API 응답 데이터 구조 및 필터링 동작 확인

## 주요 엔티티
- `CareSubject`: 케어 대상 기본 정보
- `Guardian`: 보호자 관계 및 권한 관리
- `GuardianRole`: 보호자 역할 정의 (PRIMARY/SECONDARY/TEMPORARY)
- `GuardianStatus`: 초대 상태 관리 (PENDING/ACCEPTED/REJECTED)

## 주의 사항
- PostgreSQL 데이터베이스 설정 필요
- Redis 서버 구동 필요 (토큰 관리)
- JSON 필드 사용을 위한 Hibernate 설정 확인
- 보호자 초대 이메일 발송 기능은 추후 구현 예정
- 권한 체계 테스트 시 다중 사용자 계정 필요